### PR TITLE
Fix footer social link closures

### DIFF
--- a/consultoria.html
+++ b/consultoria.html
@@ -68,11 +68,12 @@
         <a href="https://maps.app.goo.gl/mAawoEfUnV61vtST7" target="_blank" title="Ubicación">
           <img loading="lazy" src="img/facebook-icon.png" alt="Ubicación" />
         </a>
-        <a href="https://www.instagram.com/meraky62018?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==" target="_blank" title="Instagram">
-          <img loading="lazy" src="img/instagram-icon.png" alt="Instagram" />
-        <a href="https://wa.me/573155227453" target="_blank" title="WhatsApp">
-          <img loading="lazy" src="img/whatsapp-icon.png" alt="WhatsApp" />
-        </a>
+          <a href="https://www.instagram.com/meraky62018?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==" target="_blank" title="Instagram">
+            <img loading="lazy" src="img/instagram-icon.png" alt="Instagram" />
+          </a>
+          <a href="https://wa.me/573155227453" target="_blank" title="WhatsApp">
+            <img loading="lazy" src="img/whatsapp-icon.png" alt="WhatsApp" />
+          </a>
       </div>
       <p>
         <a href="index.html">Inicio</a> |

--- a/sobre-nosotros.html
+++ b/sobre-nosotros.html
@@ -101,11 +101,12 @@
         <a href="https://maps.app.goo.gl/mAawoEfUnV61vtST7" target="_blank" title="Ubicación">
           <img loading="lazy" src="img/facebook-icon.png" alt="Ubicación" />
         </a>
-        <a href="https://www.instagram.com/meraky62018?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==" target="_blank" title="Instagram">
-          <img loading="lazy" src="img/instagram-icon.png" alt="Instagram" />
-        <a href="https://wa.me/573155227453" target="_blank" title="WhatsApp">
-          <img loading="lazy" src="img/whatsapp-icon.png" alt="WhatsApp" />
-        </a>
+          <a href="https://www.instagram.com/meraky62018?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==" target="_blank" title="Instagram">
+            <img loading="lazy" src="img/instagram-icon.png" alt="Instagram" />
+          </a>
+          <a href="https://wa.me/573155227453" target="_blank" title="WhatsApp">
+            <img loading="lazy" src="img/whatsapp-icon.png" alt="WhatsApp" />
+          </a>
       </div>
       <p>
         <a href="index.html">Inicio</a> |


### PR DESCRIPTION
## Summary
- ensure Instagram and WhatsApp icons in consultoria and sobre-nosotros footers have properly closed links
- verify all footer social icons have closing anchor tags

## Testing
- `rg -U -n '<img loading="lazy" src="img/instagram-icon.png" alt="Instagram" />\s*</a>' consultoria.html sobre-nosotros.html`
- `rg -U -n 'whatsapp-icon.png" alt="WhatsApp" />\s*</a>' consultoria.html sobre-nosotros.html`
- `rg -U -n 'facebook-icon.png" alt="Ubicación" />\s*</a>' consultoria.html sobre-nosotros.html`


------
https://chatgpt.com/codex/tasks/task_e_68b0b2a541b8832d95471db901144bd8