### PR TITLE
Reemplaza carrusel por galería estática en bioactivos

### DIFF
--- a/bioactivas.html
+++ b/bioactivas.html
@@ -7,7 +7,6 @@
   <title>Bioactivas y Bioreabsorbibles - Meraky</title>
   <link rel="icon" href="/favicon.png" type="image/png">
   <link rel="stylesheet" href="css/style.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@10/swiper-bundle.min.css" />
 </head>
 <body>
   <header class="header-azul">
@@ -52,13 +51,19 @@
       </div>
     </div>
     <h2 class="titulo-secundario">Casos clínicos a la medida</h2>
-    <div class="swiper mySwiper swiper-centro">
-      <div class="swiper-wrapper">
-        <div class="swiper-slide"><img loading="lazy" src="img/implante_HA.jpg" alt="Caso clínico 1"></div>
-        <div class="swiper-slide"><img loading="lazy" src="img/pmmaha.jpg" alt="Caso clínico 2"></div>
-        <div class="swiper-slide"><img loading="lazy" src="img/HA.jpg" alt="Caso clínico 3"></div>
-      </div>
-      <div class="swiper-pagination"></div>
+    <div style="display: flex; flex-wrap: wrap; gap: 30px; justify-content: center; margin-top: 40px;">
+      <figure style="flex: 1 1 250px; max-width: 320px; text-align: center;">
+        <img loading="lazy" src="img/implante_HA.jpg" alt="Bioabsorbible tipo 1" style="width: 100%; border-radius: 10px;" />
+        <figcaption style="margin-top: 12px; font-weight: 600;">Tipo bioabsorbible 1</figcaption>
+      </figure>
+      <figure style="flex: 1 1 250px; max-width: 320px; text-align: center;">
+        <img loading="lazy" src="img/pmmaha.jpg" alt="Bioabsorbible tipo 2" style="width: 100%; border-radius: 10px;" />
+        <figcaption style="margin-top: 12px; font-weight: 600;">Tipo bioabsorbible 2</figcaption>
+      </figure>
+      <figure style="flex: 1 1 250px; max-width: 320px; text-align: center;">
+        <img loading="lazy" src="img/HA.jpg" alt="Bioabsorbible tipo 3" style="width: 100%; border-radius: 10px;" />
+        <figcaption style="margin-top: 12px; font-weight: 600;">Tipo bioabsorbible 3</figcaption>
+      </figure>
     </div>
   </main>
   <div class="servicios-nav">
@@ -76,7 +81,6 @@
       <p><a href="index.html">Inicio</a> | <a href="index.html#contacto">Contáctanos</a></p>
     </div>
   </footer>
-  <script src="https://cdn.jsdelivr.net/npm/swiper@10/swiper-bundle.min.js"></script>
   <script src="js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- reemplaza el carrusel final por una galería estática de tres imágenes con subtítulos para los bioabsorbibles
- elimina la dependencia de Swiper en la página de bioactivos al retirar los recursos del carrusel

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc513f6070832db24ae3235de5f54f